### PR TITLE
Fix the header’s style

### DIFF
--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -192,7 +192,7 @@ blockquote pre {
 header[role='banner'] {
     position: fixed;
     top: 0;
-    z-index: 1;
+    z-index: 2;
     width: 90%;
     max-width: 50rem;
     background: linear-gradient(

--- a/templates/layout.xhtml
+++ b/templates/layout.xhtml
@@ -7,7 +7,7 @@
         <link rel='stylesheet' href='{{ url_for('static', filename='css/reset.css') }}' />
         <link rel='stylesheet' href='{{ url_for('static', filename='css/fonts.css') }}' />
         <link rel='stylesheet' href='{{ url_for('pygments_css') }}' />
-        <link rel='stylesheet' href='{{ url_for('static', filename='css/screen.css') }}?10aug15' />
+        <link rel='stylesheet' href='{{ url_for('static', filename='css/screen.css') }}?10aug15b' />
         <link rel='icon' href='/favicon.ico' />
         <meta name='viewport' content='width=device-width, maximum-scale=1, initial-scale=1' />
     </head>


### PR DESCRIPTION
Styling of the header would interfere with the drop-shadow effect of
images on the page due to using the same `z-index`.  This commit fixes
this behavior by moving the header up by one level.
